### PR TITLE
Fix hg comment support and malformed patches throwing warnings

### DIFF
--- a/lib/PatchReader/DiffPrinter/raw.pm
+++ b/lib/PatchReader/DiffPrinter/raw.pm
@@ -49,7 +49,7 @@ sub next_section {
   my $this = shift;
   my ($section) = @_;
 
-  return unless $section->{old_start};
+  return unless $section->{old_start} || $section->{new_start};
   my $fh = $this->{OUTFILE};
   print $fh "@@ -$section->{old_start},$section->{old_lines} +$section->{new_start},$section->{new_lines} @@ $section->{func_info}\n";
   foreach my $line (@{$section->{lines}}) {

--- a/lib/PatchReader/DiffPrinter/raw.pm
+++ b/lib/PatchReader/DiffPrinter/raw.pm
@@ -49,6 +49,7 @@ sub next_section {
   my $this = shift;
   my ($section) = @_;
 
+  return unless $section->{old_start};
   my $fh = $this->{OUTFILE};
   print $fh "@@ -$section->{old_start},$section->{old_lines} +$section->{new_start},$section->{new_lines} @@ $section->{func_info}\n";
   foreach my $line (@{$section->{lines}}) {

--- a/lib/PatchReader/DiffPrinter/template.pm
+++ b/lib/PatchReader/DiffPrinter/template.pm
@@ -1,4 +1,4 @@
-package Bugzilla::PatchReader::DiffPrinter::template;
+package PatchReader::DiffPrinter::template;
 
 use strict;
 

--- a/lib/PatchReader/DiffPrinter/template.pm
+++ b/lib/PatchReader/DiffPrinter/template.pm
@@ -1,4 +1,4 @@
-package PatchReader::DiffPrinter::template;
+package Bugzilla::PatchReader::DiffPrinter::template;
 
 use strict;
 
@@ -14,6 +14,7 @@ sub new {
   $this->{FOOTER_TEMPLATE} = $_[3];
   $this->{ARGS} = $_[4] || {};
 
+  $this->{ARGS}{file_count} = 0;
   return $this;
 }
 
@@ -31,6 +32,7 @@ sub end_patch {
 
 sub start_file {
   my $this = shift;
+  $this->{ARGS}{file_count}++;
   $this->{ARGS}{file} = shift;
   $this->{ARGS}{file}{plus_lines} = 0;
   $this->{ARGS}{file}{minus_lines} = 0;

--- a/lib/PatchReader/Raw.pm
+++ b/lib/PatchReader/Raw.pm
@@ -173,8 +173,15 @@ sub end_lines {
   $this->{TARGET}->end_patch(@_);
 }
 
+sub _init_state {
+  my $this = shift;
+  $this->{SECTION_STATE}{minus_lines} ||= 0;
+  $this->{SECTION_STATE}{plus_lines} ||= 0;
+}
+
 sub _maybe_start_file {
   my $this = shift;
+  $this->_init_state();
   if (exists($this->{FILE_STATE}) && !$this->{FILE_STARTED} ||
       $this->{FILE_NEVER_STARTED}) {
     $this->_start_file();
@@ -183,6 +190,7 @@ sub _maybe_start_file {
 
 sub _maybe_end_file {
   my $this = shift;
+  $this->_init_state();
   return if $this->{IN_HEADER};
 
   $this->_maybe_end_section();


### PR DESCRIPTION
these changes address the most common issues encountered on bugzilla.mozilla.org.

files which are not patches currently trigger a warning, and the templates have no way of knowing that an error occurred, resulting in empty output.  by adding the file_count variable, the footer template can display an error if it's zero.

currently comments in diffs generated by hg generate a malformed unified diff, which in turn breaks interdiff.  fixed that by skipping sections which don't contain any lines when outputting as raw unified.
