### PR TITLE
Fix issues with git formatted patches.

### DIFF
--- a/lib/PatchReader/Base.pm
+++ b/lib/PatchReader/Base.pm
@@ -5,7 +5,9 @@ use strict;
 sub new {
   my $class = shift;
   $class = ref($class) || $class;
-  my $this = {};
+  my $this = {
+    IN_HEADER => 1
+  };
   bless $this, $class;
 
   return $this;

--- a/lib/PatchReader/Raw.pm
+++ b/lib/PatchReader/Raw.pm
@@ -141,7 +141,9 @@ sub next_line {
   return if $this->{IN_HEADER};
   if ($line =~ /^ /) {
     push @{$this->{SECTION_STATE}{lines}}, $line;
-  } elsif ($line =~ /^-/) {
+  } elsif ($line =~ /^-/ && $line !~ /^-- $/) {
+    # '-- ' is usually seen at the end of a git formatted patch file,
+    # Don't match it here.
     $this->{SECTION_STATE}{minus_lines}++;
     push @{$this->{SECTION_STATE}{lines}}, $line;
   } elsif ($line =~ /^\+/) {


### PR DESCRIPTION
In a patch file that has a message or some other text prior to
the commit data, PatchReader will treat any lines that start with
whitespace as actual patch data, causing mangled output.

Also the '-- ' that git places at the end of the patch data will
be parsed as patch data and included in the raw output.
